### PR TITLE
Change store format to use speedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.2.0
 
+* Relicensed as Apache 2.0.
 * Migrate serialised on-disk format to `speedy`. This means that existing stores **must be recreated**.
 
 # 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.2.0
+
+* Migrate serialised on-disk format to `speedy`. This means that existing stores **must be recreated**.
+
+# 0.1.0
+
+* Initial release.

--- a/internal/state/Cargo.toml
+++ b/internal/state/Cargo.toml
@@ -13,5 +13,6 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 speedy = "0.8.0"
 thiserror = "1.0.30"
 tokio = { version = "1.13.0", features = ["io-util", "sync"] }
+zstd = "0.9.0"
 
 [features]

--- a/internal/state/Cargo.toml
+++ b/internal/state/Cargo.toml
@@ -4,14 +4,13 @@ version = "0.1.0"
 edition = "2018"
 license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bincode = "1.3.3"
 derive_more = "0.99.16"
 git-fast-import = { path = "../../git-fast-import" }
 log = "0.4.14"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
+speedy = "0.8.0"
 thiserror = "1.0.30"
 tokio = { version = "1.13.0", features = ["io-util", "sync"] }
 

--- a/internal/state/src/error.rs
+++ b/internal/state/src/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
     #[error("serialisation error: {0:?}")]
     Serialisation(#[from] bincode::Error),
 
+    #[error("speedy error: {0:?}")]
+    Speedy(#[from] speedy::Error),
+
     #[error("unknown serialised data version: {0}")]
     UnknownSerialisationVersion(u8),
 }


### PR DESCRIPTION
Previously, this used `bincode` both for the internal serialisation and the final write to the store, but bincode turns out to be fairly inefficient at writing `Vec<u8>`s, which is all that's required. Instead, we'll use speedy, plus zstd to compress the output.