### PR TITLE
Clean up path handling

### DIFF
--- a/git-fast-import/src/commit.rs
+++ b/git-fast-import/src/commit.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{Display, Write},
     io,
+    path::PathBuf,
 };
 
 use crate::{Command, Error, Identity, Mark};
@@ -144,17 +145,17 @@ pub enum FileCommand {
     Modify {
         mode: Mode,
         mark: Mark,
-        path: String,
+        path: PathBuf,
     },
 
     /// A deleted file.
-    Delete { path: String },
+    Delete { path: PathBuf },
 
     /// A copied file.
-    Copy { from: String, to: String },
+    Copy { from: PathBuf, to: PathBuf },
 
     /// A renamed file.
-    Rename { from: String, to: String },
+    Rename { from: PathBuf, to: PathBuf },
 
     /// A special command that deletes all files in the working tree. All files
     /// that should exist after this commit must be added using
@@ -165,10 +166,12 @@ pub enum FileCommand {
 impl Display for FileCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FileCommand::Modify { mode, mark, path } => write!(f, "M {} {} {}", mode, mark, path),
-            FileCommand::Delete { path } => write!(f, "D {}", path),
-            FileCommand::Copy { from, to } => write!(f, "C {} {}", from, to),
-            FileCommand::Rename { from, to } => write!(f, "R {} {}", from, to),
+            FileCommand::Modify { mode, mark, path } => {
+                write!(f, "M {} {} {}", mode, mark, path.display())
+            }
+            FileCommand::Delete { path } => write!(f, "D {}", path.display()),
+            FileCommand::Copy { from, to } => write!(f, "C {} {}", from.display(), to.display()),
+            FileCommand::Rename { from, to } => write!(f, "R {} {}", from.display(), to.display()),
             FileCommand::DeleteAll => write!(f, "deleteall"),
         }
     }

--- a/internal/process/src/process.rs
+++ b/internal/process/src/process.rs
@@ -50,7 +50,7 @@ impl Process {
             handle: task::spawn_blocking(move || {
                 match child.wait().map(|status| (status, status.code())) {
                     Ok((_, Some(code))) if code == 0 => {
-                        log::info!("git fast-import exited with a zero status");
+                        log::debug!("git fast-import exited with a zero status");
                         Ok(())
                     }
                     Ok((_, Some(code))) => {

--- a/internal/state/src/lib.rs
+++ b/internal/state/src/lib.rs
@@ -1,8 +1,8 @@
 //! State management for `git-cvs-fast-import`.
 
 use std::{
-    ffi::OsStr,
     io::{Read, Write},
+    path::Path,
     sync::Arc,
     time::SystemTime,
 };
@@ -141,7 +141,7 @@ impl Manager {
     #[allow(clippy::too_many_arguments)]
     pub async fn add_file_revision<I>(
         &self,
-        path: &OsStr,
+        path: &Path,
         revision: &[u8],
         mark: Option<Mark>,
         branches: I,
@@ -155,7 +155,7 @@ impl Manager {
     {
         self.file_revisions.write().await.add(
             file_revision::Key {
-                path: path.to_os_string(),
+                path: path.to_path_buf(),
                 revision: revision.to_vec(),
             },
             mark.map(|mark| mark.into()),
@@ -187,13 +187,13 @@ impl Manager {
 
     pub async fn get_file_revision(
         &self,
-        path: &OsStr,
+        path: &Path,
         revision: &[u8],
     ) -> Result<Arc<FileRevision>, Error> {
         match self.file_revisions.read().await.get_by_key(path, revision) {
             Some(revision) => Ok(revision),
             None => Err(Error::NoFileRevisionForKey(file_revision::Key {
-                path: path.to_os_string(),
+                path: path.to_path_buf(),
                 revision: revision.to_vec(),
             })),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,11 +247,9 @@ where
                 Some(mark) => builder.add_file_command(FileCommand::Modify {
                     mode: git_fast_import::Mode::Normal,
                     mark: mark.into(),
-                    path: path.to_string_lossy().into(),
+                    path: path.clone(),
                 }),
-                None => builder.add_file_command(FileCommand::Delete {
-                    path: path.to_string_lossy().into(),
-                }),
+                None => builder.add_file_command(FileCommand::Delete { path: path.clone() }),
             };
         }
 
@@ -313,15 +311,16 @@ async fn send_tags(state: &Manager, output: &Output) -> anyhow::Result<()> {
         if let Some(file_revision_ids) = state.get_file_revisions_for_tag(tag).await.iter() {
             for file_revision_id in file_revision_ids.iter() {
                 let file_revision = state.get_file_revision_by_id(*file_revision_id).await?;
-                let path = file_revision.key.path.to_string_lossy().into_owned();
 
                 match file_revision.mark {
                     Some(mark) => builder.add_file_command(FileCommand::Modify {
                         mode: git_fast_import::Mode::Normal,
                         mark: mark.into(),
-                        path,
+                        path: file_revision.key.path.clone(),
                     }),
-                    None => builder.add_file_command(FileCommand::Delete { path }),
+                    None => builder.add_file_command(FileCommand::Delete {
+                        path: file_revision.key.path.clone(),
+                    }),
                 };
 
                 // Find out which patchset this file revision is in, if any, and

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
 
@@ -40,7 +40,7 @@ pub(crate) struct Message {
 /// an implementation detail.
 #[derive(Debug)]
 pub(crate) struct FileRevision {
-    path: OsString,
+    path: PathBuf,
     revision: Vec<u8>,
     mark: Option<Mark>,
     branches: Vec<Vec<u8>>,
@@ -63,7 +63,7 @@ impl Observer {
             while let Some(msg) = file_revision_rx.recv().await {
                 let id = task_state
                     .add_file_revision(
-                        msg.file_revision.path.as_os_str(),
+                        msg.file_revision.path.as_path(),
                         &msg.file_revision.revision,
                         msg.file_revision.mark,
                         msg.file_revision.branches.iter(),
@@ -103,7 +103,7 @@ impl Observer {
     /// manager.
     pub(crate) async fn file_revision(
         &self,
-        path: &OsStr,
+        path: &Path,
         revision: &Num,
         branches: &[Num],
         mark: Option<Mark>,
@@ -114,7 +114,7 @@ impl Observer {
 
         self.file_revision_tx.send(Message {
             file_revision: FileRevision {
-                path: path.to_os_string(),
+                path: path.to_path_buf(),
                 revision: revision.to_vec(),
                 mark,
                 branches: branches.iter().map(|branch| branch.to_vec()).collect(),


### PR DESCRIPTION
This converts (almost) every use of `OsStr` and `OsString` to `Path` and `PathBuf`, respectively. Much cleaner!